### PR TITLE
Fixed crash due to uninitialized variable

### DIFF
--- a/main.c
+++ b/main.c
@@ -15,7 +15,7 @@ const char *VersionString = MODULE_ID"V306"; // module id and version of the fir
 
 static SPIChannelTypeDef *EEPROM_SPIChannel;
 
-static SPIChannelTypeDef *TMC6200_SPIChannel;
+extern SPIChannelTypeDef *TMC6200_SPIChannel;
 
 
 /* Keep as is! This lines are important for the update functionality. */


### PR DESCRIPTION
The TMC6200_SPIChannel variable in TMC6200_eval.c was not initialized correctly, resulting in a crash when trying to use the read/write functions of the TMC6200.